### PR TITLE
Adding state machine to transition between commit log states

### DIFF
--- a/lib/rosette/core.rb
+++ b/lib/rosette/core.rb
@@ -73,6 +73,7 @@ module Rosette
     autoload :StaticExtractor,               'rosette/core/extractor/static_extractor'
     autoload :Phrase,                        'rosette/core/extractor/phrase'
     autoload :Translation,                   'rosette/core/extractor/translation'
+    autoload :CommitLogStatus,               'rosette/core/extractor/commit_log_status'
     autoload :ExtractorConfig,               'rosette/core/extractor/extractor_config'
     autoload :ExtractorConfigurationFactory, 'rosette/core/extractor/extractor_config'
     autoload :RepoConfig,                    'rosette/core/extractor/repo_config'

--- a/lib/rosette/core/extractor/commit_log_status.rb
+++ b/lib/rosette/core/extractor/commit_log_status.rb
@@ -1,0 +1,48 @@
+# encoding: UTF-8
+
+require 'state_machine'
+
+module Rosette
+  module Core
+
+    module CommitLogStatus
+      include Rosette::DataStores::PhraseStatus
+
+      def self.included(base)
+        base.class_eval do
+          state_machine :status, initial: UNTRANSLATED do
+            # called on every push
+            event :push do
+              transition [UNTRANSLATED, PENDING] => PENDING
+            end
+
+            # called on every pull
+            event :pull do
+              transition [PENDING, PULLING] => PULLING
+              transition PULLED => TRANSLATED
+            end
+
+            # called on every complete
+            event :complete do
+              transition [PENDING, PULLING] => PULLING
+              transition TRANSLATED => TRANSLATED
+              transition PULLED => PULLED
+            end
+
+            # called by completer when phrases are fully translated
+            event :translate do
+              transition [PULLING, PULLED] => PULLED
+              transition TRANSLATED => TRANSLATED
+            end
+
+            # called when jgit can't find the commit
+            event :missing do
+              transition all => MISSING
+            end
+          end
+        end
+      end
+    end
+
+  end
+end

--- a/lib/rosette/core/extractor/commit_log_status.rb
+++ b/lib/rosette/core/extractor/commit_log_status.rb
@@ -24,15 +24,14 @@ module Rosette
 
             # called on every complete
             event :complete do
-              transition [PENDING, PULLING] => PULLING
-              transition TRANSLATED => TRANSLATED
-              transition PULLED => PULLED
+              transition PULLING => PULLED
+              transition [PULLED, TRANSLATED] => TRANSLATED
             end
 
-            # called by completer when phrases are fully translated
+            # handles the zero phrases case (commit bypasses pulling
+            # state if it introduces no new/changed phrases)
             event :translate do
-              transition [PULLING, PULLED] => PULLED
-              transition TRANSLATED => TRANSLATED
+              transition all => TRANSLATED
             end
 
             # called when jgit can't find the commit

--- a/lib/rosette/core/extractor/commit_log_status.rb
+++ b/lib/rosette/core/extractor/commit_log_status.rb
@@ -5,11 +5,15 @@ require 'state_machine'
 module Rosette
   module Core
 
+    # Provides a state machine for transitioning between the possible states of
+    # a commit log.
     module CommitLogStatus
       include Rosette::DataStores::PhraseStatus
 
       def self.included(base)
         base.class_eval do
+          class_initialize = instance_method(:initialize)
+
           state_machine :status, initial: UNTRANSLATED do
             # called on every push
             event :push do
@@ -38,6 +42,21 @@ module Rosette
             event :missing do
               transition all => MISSING
             end
+          end
+
+          state_machine_initialize = instance_method(:initialize)
+
+          # state_machine overrides base's initializer, which can be bad.
+          # For example, if base's initializer sets up the initial state of
+          # the state machine (eg. @state = 'foo'), the fact that the state
+          # machine's initializer gets called first means @state doesn't get
+          # set and therefore isn't available to the state machine (the
+          # initial state will be nil). By grabbing references to both
+          # initialize methods, we can re-define initialize to call them in
+          # the right order.
+          define_method(:initialize) do |*args, &block|
+            class_initialize.bind(self).call(*args, &block)
+            state_machine_initialize.bind(self).call(*args, &block)
           end
         end
       end

--- a/lib/rosette/data_stores.rb
+++ b/lib/rosette/data_stores.rb
@@ -4,7 +4,8 @@ module Rosette
 
   # Namespace for Rosette's data stores.
   module DataStores
-    autoload :Errors, 'rosette/data_stores/errors'
+    autoload :Errors,       'rosette/data_stores/errors'
+    autoload :PhraseStatus, 'rosette/data_stores/phrase_status'
   end
 
 end

--- a/rosette-core.gemspec
+++ b/rosette-core.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'progress-reporters', '~> 1.0.0'
   s.add_dependency 'activesupport', '~> 3.2.0'
+  s.add_dependency 'state_machine', '~> 1.2.0'
   s.requirements << "jar 'org.eclipse.jgit:org.eclipse.jgit', '3.4.1.201406201815-r'"
 
   s.require_path = 'lib'

--- a/spec/core/extractor/commit_log_status_spec.rb
+++ b/spec/core/extractor/commit_log_status_spec.rb
@@ -45,9 +45,9 @@ describe CommitLogStatus do
     end
 
     describe 'on translate' do
-      it 'returns false and has no effect' do
-        expect(instance.translate).to be_falsy
-        expect(instance.status).to eq(PhraseStatus::UNTRANSLATED)
+      it 'transitions to TRANSLATED' do
+        expect(instance.translate).to be_truthy
+        expect(instance.status).to eq(PhraseStatus::TRANSLATED)
       end
     end
 
@@ -77,16 +77,16 @@ describe CommitLogStatus do
     end
 
     describe 'on complete' do
-      it 'transitions to PULLED' do
-        expect(instance.complete).to be_truthy
-        expect(instance.status).to eq(PhraseStatus::PULLING)
+      it 'returns false and has no effect' do
+        expect(instance.complete).to be_falsy
+        expect(instance.status).to eq(PhraseStatus::PENDING)
       end
     end
 
     describe 'on translate' do
-      it 'returns false and has no effect' do
-        expect(instance.translate).to be_falsy
-        expect(instance.status).to eq(PhraseStatus::PENDING)
+      it 'transitions to TRANSLATED' do
+        expect(instance.translate).to be_truthy
+        expect(instance.status).to eq(PhraseStatus::TRANSLATED)
       end
     end
 
@@ -116,16 +116,16 @@ describe CommitLogStatus do
     end
 
     describe 'on complete' do
-      it 'stays PULLING' do
+      it 'transitions to PULLED' do
         expect(instance.complete).to be_truthy
-        expect(instance.status).to eq(PhraseStatus::PULLING)
+        expect(instance.status).to eq(PhraseStatus::PULLED)
       end
     end
 
     describe 'on translate' do
-      it 'transitions to PULLED' do
+      it 'transitions to TRANSLATED' do
         expect(instance.translate).to be_truthy
-        expect(instance.status).to eq(PhraseStatus::PULLED)
+        expect(instance.status).to eq(PhraseStatus::TRANSLATED)
       end
     end
 
@@ -155,16 +155,16 @@ describe CommitLogStatus do
     end
 
     describe 'on complete' do
-      it 'stays PULLED' do
+      it 'transitions to TRANSLATED' do
         expect(instance.complete).to be_truthy
-        expect(instance.status).to eq(PhraseStatus::PULLED)
+        expect(instance.status).to eq(PhraseStatus::TRANSLATED)
       end
     end
 
     describe 'on translate' do
-      it 'stays PULLED' do
+      it 'transitions to TRANSLATED' do
         expect(instance.translate).to be_truthy
-        expect(instance.status).to eq(PhraseStatus::PULLED)
+        expect(instance.status).to eq(PhraseStatus::TRANSLATED)
       end
     end
 
@@ -201,7 +201,7 @@ describe CommitLogStatus do
     end
 
     describe 'on translate' do
-      it 'stays TRANSLATED' do
+      it 'transitions to TRANSLATED' do
         expect(instance.translate).to be_truthy
         expect(instance.status).to eq(PhraseStatus::TRANSLATED)
       end

--- a/spec/core/extractor/commit_log_status_spec.rb
+++ b/spec/core/extractor/commit_log_status_spec.rb
@@ -1,0 +1,217 @@
+# encoding: UTF-8
+
+require 'spec_helper'
+
+include Rosette::Core
+include Rosette::DataStores
+
+class CommitLogStatusTester
+  include CommitLogStatus
+
+  attr_accessor :state
+
+  def initialize(status)
+    @status = status
+  end
+end
+
+describe CommitLogStatus do
+  let(:instance) do
+    CommitLogStatusTester.new(status)
+  end
+
+  context 'with an UNTRANSLATED status' do
+    let(:status) { PhraseStatus::UNTRANSLATED }
+
+    describe 'on push' do
+      it 'transitions to PENDING' do
+        expect(instance.push).to be_truthy
+        expect(instance.status).to eq(PhraseStatus::PENDING)
+      end
+    end
+
+    describe 'on pull' do
+      it 'returns false and has no effect' do
+        expect(instance.pull).to be_falsy
+        expect(instance.status).to eq(PhraseStatus::UNTRANSLATED)
+      end
+    end
+
+    describe 'on complete' do
+      it 'returns false and has no effect' do
+        expect(instance.complete).to be_falsy
+        expect(instance.status).to eq(PhraseStatus::UNTRANSLATED)
+      end
+    end
+
+    describe 'on translate' do
+      it 'returns false and has no effect' do
+        expect(instance.translate).to be_falsy
+        expect(instance.status).to eq(PhraseStatus::UNTRANSLATED)
+      end
+    end
+
+    describe 'on missing' do
+      it 'transitions to MISSING' do
+        expect(instance.missing).to be_truthy
+        expect(instance.status).to eq(PhraseStatus::MISSING)
+      end
+    end
+  end
+
+  context 'with a PENDING status' do
+    let(:status) { PhraseStatus::PENDING }
+
+    describe 'on push' do
+      it 'stays PENDING' do
+        expect(instance.push).to be_truthy
+        expect(instance.status).to eq(PhraseStatus::PENDING)
+      end
+    end
+
+    describe 'on pull' do
+      it 'transitions to PULLING' do
+        expect(instance.pull).to be_truthy
+        expect(instance.status).to eq(PhraseStatus::PULLING)
+      end
+    end
+
+    describe 'on complete' do
+      it 'transitions to PULLED' do
+        expect(instance.complete).to be_truthy
+        expect(instance.status).to eq(PhraseStatus::PULLING)
+      end
+    end
+
+    describe 'on translate' do
+      it 'returns false and has no effect' do
+        expect(instance.translate).to be_falsy
+        expect(instance.status).to eq(PhraseStatus::PENDING)
+      end
+    end
+
+    describe 'on missing' do
+      it 'transitions to MISSING' do
+        expect(instance.missing).to be_truthy
+        expect(instance.status).to eq(PhraseStatus::MISSING)
+      end
+    end
+  end
+
+  context 'with a PULLING status' do
+    let(:status) { PhraseStatus::PULLING }
+
+    describe 'on push' do
+      it 'returns false and has no effect' do
+        expect(instance.push).to be_falsy
+        expect(instance.status).to eq(PhraseStatus::PULLING)
+      end
+    end
+
+    describe 'on pull' do
+      it 'stays PULLING' do
+        expect(instance.pull).to be_truthy
+        expect(instance.status).to eq(PhraseStatus::PULLING)
+      end
+    end
+
+    describe 'on complete' do
+      it 'stays PULLING' do
+        expect(instance.complete).to be_truthy
+        expect(instance.status).to eq(PhraseStatus::PULLING)
+      end
+    end
+
+    describe 'on translate' do
+      it 'transitions to PULLED' do
+        expect(instance.translate).to be_truthy
+        expect(instance.status).to eq(PhraseStatus::PULLED)
+      end
+    end
+
+    describe 'on missing' do
+      it 'transitions to MISSING' do
+        expect(instance.missing).to be_truthy
+        expect(instance.status).to eq(PhraseStatus::MISSING)
+      end
+    end
+  end
+
+  context 'with a PULLED status' do
+    let(:status) { PhraseStatus::PULLED }
+
+    describe 'on push' do
+      it 'returns false and has no effect' do
+        expect(instance.push).to be_falsy
+        expect(instance.status).to eq(PhraseStatus::PULLED)
+      end
+    end
+
+    describe 'on pull' do
+      it 'transitions to TRANSLATED' do
+        expect(instance.pull).to be_truthy
+        expect(instance.status).to eq(PhraseStatus::TRANSLATED)
+      end
+    end
+
+    describe 'on complete' do
+      it 'stays PULLED' do
+        expect(instance.complete).to be_truthy
+        expect(instance.status).to eq(PhraseStatus::PULLED)
+      end
+    end
+
+    describe 'on translate' do
+      it 'stays PULLED' do
+        expect(instance.translate).to be_truthy
+        expect(instance.status).to eq(PhraseStatus::PULLED)
+      end
+    end
+
+    describe 'missing' do
+      it 'transitions to MISSING' do
+        expect(instance.missing).to be_truthy
+        expect(instance.status).to eq(PhraseStatus::MISSING)
+      end
+    end
+  end
+
+  context 'with a TRANSLATED status' do
+    let(:status) { PhraseStatus::TRANSLATED }
+
+    describe 'on push' do
+      it 'returns false and has no effect' do
+        expect(instance.push).to be_falsy
+        expect(instance.status).to eq(PhraseStatus::TRANSLATED)
+      end
+    end
+
+    describe 'on pull' do
+      it 'returns false and has no effect' do
+        expect(instance.pull).to be_falsy
+        expect(instance.status).to eq(PhraseStatus::TRANSLATED)
+      end
+    end
+
+    describe 'on complete' do
+      it 'stays TRANSLATED' do
+        expect(instance.complete).to be_truthy
+        expect(instance.status).to eq(PhraseStatus::TRANSLATED)
+      end
+    end
+
+    describe 'on translate' do
+      it 'stays TRANSLATED' do
+        expect(instance.translate).to be_truthy
+        expect(instance.status).to eq(PhraseStatus::TRANSLATED)
+      end
+    end
+
+    describe 'missing' do
+      it 'transitions to MISSING' do
+        expect(instance.missing).to be_truthy
+        expect(instance.status).to eq(PhraseStatus::MISSING)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We’re doing this pretty manually right now. The state machine makes state transitions easier to read and modify.