### PR TITLE
Refactor StatusCommand to return the status of the entire branch

### DIFF
--- a/lib/rosette/core/commands/git/status_command.rb
+++ b/lib/rosette/core/commands/git/status_command.rb
@@ -118,7 +118,7 @@ module Rosette
           commit_logs = datastore.each_commit_log_with_status(repo_name, statuses)
 
           commit_logs.each_with_object([]) do |commit_log, ret|
-            refs = repo_config.repo.remote_refs_for_commit(
+            refs = repo_config.repo.refs_containing(
               commit_log.commit_id, rev_walk
             )
 

--- a/lib/rosette/core/commands/git/status_command.rb
+++ b/lib/rosette/core/commands/git/status_command.rb
@@ -52,7 +52,7 @@ module Rosette
         def execute
           repo_config = get_repo(repo_name)
           rev_walk = RevWalk.new(repo_config.repo.jgit_repo)
-          refs = repo_config.repo.remote_refs_for_commit(
+          refs = repo_config.repo.refs_containing(
             commit_id, rev_walk
           )
 

--- a/lib/rosette/core/commands/git/status_command.rb
+++ b/lib/rosette/core/commands/git/status_command.rb
@@ -31,16 +31,19 @@ module Rosette
         include WithRepoName
         include WithRef
 
-        # Computes the status for the configured repository and git ref.
+        # Computes the status for the configured repository and git ref. The
+        # status is computed by identifying the branch the ref belongs to, then
+        # examining and merging the statuses of all commits that belong to
+        # that branch.
         #
         # @see Rosette::DataStores::PhraseStatus
         #
-        # @return [Hash] a hash of status information for the commit:
+        # @return [Hash] a hash of status information for the ref:
         #   * +commit_id+: the commit id of the ref the status came from.
         #   * +status+: One of +"PENDING"+, +"UNTRANSLATED"+, or +"TRANSLATED"+.
         #   * +phrase_count+: The number of phrases found in the commit.
-        #   * +locales+: An array of locale statuses having these entries:
-        #     * +locale+: The locale code.
+        #   * +locales+: A hash of locale codes to locale statuses having these
+        #     entries:
         #     * +percent_translated+: The percentage of +phrase_count+ phrases
         #       that are currently translated in +locale+ for this commit.
         #       In other words, +translated_count+ +/+ +phrase_count+.
@@ -48,33 +51,88 @@ module Rosette
         #       for this commit.
         def execute
           repo_config = get_repo(repo_name)
-          locales = repo_config.locales.map(&:code)
-          rev_commit = repo_config.repo.get_rev_commit(commit_id)
+          rev_walk = RevWalk.new(repo_config.repo.jgit_repo)
+          refs = repo_config.repo.remote_refs_for_commit(
+            commit_id, rev_walk
+          )
 
-          datastore.commit_log_status(repo_name, commit_id).tap do |status|
-            if status
-              status[:locales] = fill_in_missing_locales(locales, status)
-            end
-          end
+          commit_logs = commit_logs_for(refs.map(&:getName), repo_config, rev_walk)
+          status = derive_status_from(commit_logs)
+          phrase_count = derive_phrase_count_from(commit_logs)
+          locale_statuses = derive_locale_statuses_from(commit_logs)
+
+          {
+            status: status,
+            phrase_count: phrase_count,
+            locales: fill_in_missing_locales(
+              repo_config.locales, locale_statuses
+            )
+          }
         end
 
         protected
 
-        def fill_in_missing_locales(locales, status)
-          locales.map do |locale|
-            found_locale = status[:locales].find do |status_locale|
-              status_locale[:locale] == locale
-            end
+        def derive_status_from(commit_logs)
+          ps = Rosette::DataStores::PhraseStatus
+          entry = commit_logs.min_by { |entry| ps.index(entry.status) }
+          entry.status if entry
+        end
 
-            if found_locale
-              found_locale
+        def derive_phrase_count_from(commit_logs)
+          commit_logs.inject(0) { |sum, entry| sum + entry.phrase_count }
+        end
+
+        def derive_locale_statuses_from(commit_logs)
+          commit_logs.each_with_object({}) do |commit_log, ret|
+            locale_entries = datastore.commit_log_locales_for(repo_name, commit_log.commit_id)
+            locale_entries.each do |locale_entry|
+              ret[locale_entry.locale] ||= { translated_count: 0 }
+
+              ret[locale_entry.locale].tap do |locale_hash|
+                locale_hash[:translated_count] += locale_entry.translated_count
+                locale_hash[:percent_translated] = percentage(
+                  commit_log.phrase_count || 0,
+                  locale_hash.fetch(:translated_count, 0) || 0
+                )
+              end
+            end
+          end
+        end
+
+        def commit_logs_for(branch_names, repo_config, rev_walk)
+          statuses = Rosette::DataStores::PhraseStatus.incomplete
+          commit_logs = datastore.each_commit_log_with_status(repo_name, statuses)
+
+          commit_logs.each_with_object([]) do |commit_log, ret|
+            refs = repo_config.repo.remote_refs_for_commit(
+              commit_log.commit_id, rev_walk
+            )
+
+            if refs.any? { |ref| branch_names.include?(ref.getName) }
+              ret << commit_log
+            end
+          end
+        end
+
+        def fill_in_missing_locales(locales, locale_statuses)
+          locales.each_with_object({}) do |locale, ret|
+            if found_locale_status = locale_statuses[locale.code]
+              ret[locale.code] = found_locale_status
             else
-              {
-                locale: locale,
+              ret[locale.code] = {
+                locale: locale.code,
                 percent_translated: 0.0,
                 translated_count: 0
               }
             end
+          end
+        end
+
+        def percentage(dividend, divisor)
+          if divisor > 0
+            (dividend.to_f / divisor.to_f).round(2)
+          else
+            0.0
           end
         end
       end

--- a/lib/rosette/core/git/repo.rb
+++ b/lib/rosette/core/git/repo.rb
@@ -13,6 +13,7 @@ java_import 'org.eclipse.jgit.lib.ObjectId'
 java_import 'org.eclipse.jgit.lib.RefDatabase'
 java_import 'org.eclipse.jgit.revwalk.RevSort'
 java_import 'org.eclipse.jgit.revwalk.RevWalk'
+java_import 'org.eclipse.jgit.revwalk.RevWalkUtils'
 
 module Rosette
   module Core
@@ -330,11 +331,9 @@ module Rosette
       #   contain +commit_id_or_ref+.
       def refs_containing(commit_id_or_ref, walker = rev_walker)
         commit = get_rev_commit(commit_id_or_ref, walker)
-
-        jgit_repo.refDatabase.getRefs(RefDatabase::ALL).each_with_object([]) do |(_, ref), ret|
-          head_commit = walker.parseCommit(ref.getObjectId)
-          ret << ref if walker.isMergedInto(commit, head_commit)
-        end
+        RevWalkUtils.findBranchesReachableFrom(
+          commit, walker, jgit_repo.refDatabase.getRefs(RefDatabase::ALL).values
+        )
       end
 
       private

--- a/lib/rosette/core/git/repo.rb
+++ b/lib/rosette/core/git/repo.rb
@@ -321,6 +321,15 @@ module Rosette
         all_head_refs.map { |ref| get_rev_commit(ref, walker) }
       end
 
+      def remote_refs_for_commit(commit_id_or_ref, walker = rev_walker)
+        commit = get_rev_commit(commit_id_or_ref, walker)
+
+        jgit_repo.refDatabase.getRefs(RefDatabase::ALL).each_with_object([]) do |(_, ref), ret|
+          head_commit = walker.parseCommit(ref.getObjectId)
+          ret << ref if walker.isMergedInto(commit, head_commit)
+        end
+      end
+
       private
 
       def git

--- a/lib/rosette/core/git/repo.rb
+++ b/lib/rosette/core/git/repo.rb
@@ -321,7 +321,14 @@ module Rosette
         all_head_refs.map { |ref| get_rev_commit(ref, walker) }
       end
 
-      def remote_refs_for_commit(commit_id_or_ref, walker = rev_walker)
+      # Get a list of refs (i.e. branches) that contain the given commit id.
+      #
+      # @param [String] commit_id_or_ref The git commit id or ref to get refs
+      #   for. This method returns all the refs that contain this commit.
+      # @param [Java::OrgEclipseJgitRevwalk::RevWalk] walker The walker to use.
+      # @return [Array<Java::OrgEclipseJgitLib::Ref>] The list of refs that
+      #   contain +commit_id_or_ref+.
+      def refs_containing(commit_id_or_ref, walker = rev_walker)
         commit = get_rev_commit(commit_id_or_ref, walker)
 
         jgit_repo.refDatabase.getRefs(RefDatabase::ALL).each_with_object([]) do |(_, ref), ret|

--- a/lib/rosette/data_stores/phrase_status.rb
+++ b/lib/rosette/data_stores/phrase_status.rb
@@ -27,6 +27,30 @@ module Rosette
       # Indicates that the commit no longer exists, i.e. the associated branch
       # was deleted or was force-pushed over.
       MISSING = 'MISSING'
+
+      def self.all
+        @all ||= [
+          UNTRANSLATED, PENDING, PULLING, PULLED, TRANSLATED, MISSING
+        ]
+      end
+
+      def self.statuses
+        @statuses ||= [
+          UNTRANSLATED, PENDING, PULLING, PULLED, TRANSLATED
+        ]
+      end
+
+      def self.incomplete
+        @statuses ||= [
+          UNTRANSLATED, PENDING, PULLING, PULLED
+        ]
+      end
+
+      def self.index(status)
+        (@status_index ||= {}).fetch(status) do
+          statuses.index(status)
+        end
+      end
     end
 
   end

--- a/lib/rosette/data_stores/phrase_status.rb
+++ b/lib/rosette/data_stores/phrase_status.rb
@@ -41,7 +41,7 @@ module Rosette
       end
 
       def self.incomplete
-        @statuses ||= [
+        @incomplete ||= [
           UNTRANSLATED, PENDING, PULLING, PULLED
         ]
       end

--- a/spec/core/git/repo_spec.rb
+++ b/spec/core/git/repo_spec.rb
@@ -180,5 +180,14 @@ describe Repo do
         expect(repo.commit_count).to eq(3)
       end
     end
+
+    describe '#refs_containing' do
+      it 'returns the refs that contain the given commit' do
+        refs = repo.refs_containing(commits.last.getId.name)
+        expect(refs.map(&:getName)).to eq([
+          "HEAD", "refs/heads/master", "refs/heads/mybranch"
+        ])
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -70,6 +70,10 @@ RSpec.configure do |config|
   config.after(:each) do
     TestHelpers::Fixtures.cleanup
   end
+
+  config.after(:each) do
+    Rosette::DataStores::InMemoryDataStore.all_entries.clear
+  end
 end
 
 TestPhrase = Struct.new(:key, :meta_key, :file, :commit_id) do


### PR DESCRIPTION
Currently, the StatusCommand only returns the status for the given commit or ref. This PR modifies it to return the status for the entire branch so that phrases that were introduced in earlier commits don’t get ignored by, for example, catapult.