### PR TITLE
Add strict and non-strict modes to ShowCommand

### DIFF
--- a/lib/rosette/core/commands/git/diff_command.rb
+++ b/lib/rosette/core/commands/git/diff_command.rb
@@ -177,11 +177,13 @@ module Rosette
           head_snapshot = {}
           head_paths = []
 
-          diff.each do |diff_entry|
-            path = diff_entry.getNewPath
-            if repo_config.extractor_configs.any? { |ext| ext.matches?(path) }
-              head_snapshot[path] = head_commit_id
-              head_paths << (path == '/dev/null' ? diff_entry.getOldPath : path)
+          diff.each_pair do |_, diff_entries|
+            diff_entries.each do |diff_entry|
+              path = diff_entry.getNewPath
+              if repo_config.extractor_configs.any? { |ext| ext.matches?(path) }
+                head_snapshot[path] = head_commit_id
+                head_paths << (path == '/dev/null' ? diff_entry.getOldPath : path)
+              end
             end
           end
 

--- a/lib/rosette/core/commands/git/show_command.rb
+++ b/lib/rosette/core/commands/git/show_command.rb
@@ -30,6 +30,16 @@ module Rosette
         include WithRepoName
         include WithRef
 
+        attr_reader :strict
+        alias_method :strict?, :strict
+
+        DiffSnapshot = Struct.new(:snapshot, :paths)
+
+        def initialize(*args)
+          super
+          @strict = true
+        end
+
         # Computes the show (i.e. parent diff).
         # @return [Hash] a hash of differences, grouped by added/removed/modified keys. Each
         #   value is an array of phrases. For added and removed phrases, the phrase hashes
@@ -38,44 +48,127 @@ module Rosette
         #   contains the previous key of the phrase. See the example above for a visual
         #   representation of the diff hash.
         def execute
-          repo_config = get_repo(repo_name)
-          rev_walker = RevWalk.new(repo_config.repo.jgit_repo)
-          diff_finder = DiffFinder.new(repo_config.repo.jgit_repo, rev_walker)
+          parent_commit_ids = build_parent_commit_list
+          phrase_diff = calculate_phrase_diff_against(parent_commit_ids)
+          filter_phrase_diff(parent_commit_ids, phrase_diff)
+        end
 
-          repo = repo_config.repo
-          diff = repo.ref_diff_with_parent(commit_id, diff_finder)
-          rev = repo.get_rev_commit(commit_id, rev_walker)
-          parent_commit_ids = repo.parent_ids_of(rev)
+        # Sets a boolean value that determines if the diff should be made
+        # against true parents of the given commit or the most recently
+        # processed parents. If set to +true+, the diff will be computed
+        # between the given commit and its actual (true) parents, and an error
+        # will be raised if any of the parents have not been processed by
+        # Rosette (i.e. don't exist in the commit log). If set to +false+, the
+        # diff will be computed between the given commit and the most recent
+        # parents that have been processed. For each parent of the given commit,
+        # +ShowCommand+ will traverse the commit history looking for a processed
+        # commit and use it in place of the true parent (assuming the true
+        # parent hasn't been processed yet). It's worth noting that setting
+        # +strict+ to +false+ may potentially produce results that contain
+        # phrases that were not introduced exclusively in the given commit.
+        # Since such behavior is different from what git clients return, and
+        # therefore possibly unexpected, strictness is enabled (set to +true+)
+        # by default.
+        #
+        # @param [Boolean] strict
+        # @return [self]
+        def set_strict(strict)
+          @strict = strict
+          self
+        end
 
-          child_snapshot = {}
+        protected
+
+        # if parent_commit_id is processed, it will get returned (i.e. it will
+        # start looking at parent_commit_id, not parent_commit_id - 1).
+        def get_closest_processed_parent(parent_commit_id)
+          parent = repo.each_commit_starting_at(parent_commit_id).find do |rev|
+            datastore.commit_log_exists?(repo_name, rev.getId.name)
+          end
+
+          parent.getId.name if parent
+        end
+
+        def build_parent_commit_list
+          repo.parents_of(repo.get_rev_commit(commit_id)).map do |parent|
+            if strict?
+              parent.getId.name
+            else
+              get_closest_processed_parent(parent.getId.name)
+            end
+          end
+        end
+
+        def compute_git_diff_against(parent_commit_ids)
+          rev_walker = RevWalk.new(repo.jgit_repo)
+          diff_finder = DiffFinder.new(repo.jgit_repo, rev_walker)
+          repo.diff(parent_commit_ids, commit_id, [], diff_finder)
+        end
+
+        def compute_paths(diff)
           child_paths = []
 
-          diff.each do |diff_entry|
-            path = diff_entry.getNewPath
-            if repo_config.extractor_configs.any? { |ext| ext.matches?(path) }
-              child_snapshot[path] = commit_id
-              child_paths << (path == '/dev/null' ? diff_entry.getOldPath : path)
+          diff.each_with_object([]) do |(_, diff_entries), ret|
+            diff_entries.each do |diff_entry|
+              path = diff_entry.getNewPath
+
+              if repo_config.extractor_configs.any? { |ext| ext.matches?(path) }
+                ret << get_path(diff_entry)
+              end
             end
           end
+        end
 
-          child_phrases = datastore.phrases_by_commits(repo_name, child_snapshot).to_a
+        def get_path(diff_entry)
+          new_path = diff_entry.getNewPath
 
-          parent_phrases = parent_commit_ids.flat_map do |parent_commit_id|
-            parent_snapshot = take_snapshot(repo_config, parent_commit_id, child_paths)
-            ensure_commits_have_been_processed(parent_snapshot.values)
+          if new_path == '/dev/null'
+            diff_entry.getOldPath
+          else
+            new_path
+          end
+        end
+
+        def retrieve_child_phrases(paths)
+          snapshot = take_snapshot(repo_config, commit_id, paths)
+          datastore.phrases_by_commits(repo_name, snapshot).to_a
+        end
+
+        def retrieve_parent_phrases(parent_commit_ids, paths)
+          ensure_commits_have_been_processed(parent_commit_ids)
+
+          parent_commit_ids.flat_map do |parent_commit_id|
+            parent_snapshot = take_snapshot(
+              repo_config, parent_commit_id, paths
+            )
+
             datastore.phrases_by_commits(repo_name, parent_snapshot).to_a
           end
+        end
 
-          diff = compare(child_phrases, parent_phrases)
+        def calculate_phrase_diff_against(parent_commit_ids)
+          git_diff = compute_git_diff_against(parent_commit_ids)
+          paths = compute_paths(git_diff)
+          child_phrases = retrieve_child_phrases(paths)
+          parent_phrases = retrieve_parent_phrases(parent_commit_ids, paths)
+          compare(child_phrases, parent_phrases)
+        end
 
-          diff.each_with_object({}) do |(state, diff_entries), ret|
+        def filter_phrase_diff(parent_commit_ids, phrase_diff)
+          phrase_diff.each_with_object({}) do |(state, diff_entries), ret|
             ret[state] = diff_entries.select do |diff_entry|
-              diff_entry.phrase.commit_id == commit_id || (
-                diff_entry.state == :removed &&
-                  parent_commit_ids.include?(diff_entry.phrase.commit_id)
-              )
+              diff_entry.phrase.commit_id == commit_id ||
+                diff_entry.state == :removed
             end
           end
+        end
+
+        def repo_config
+          get_repo(repo_name)
+        end
+
+        def repo
+          repo_config.repo
         end
       end
 

--- a/lib/rosette/core/extractor/commit_processor.rb
+++ b/lib/rosette/core/extractor/commit_processor.rb
@@ -51,10 +51,12 @@ module Rosette
           diff_finder = DiffFinder.new(repo_config.repo.jgit_repo, rev_walk)
           commit = repo_config.repo.get_rev_commit(commit_ref, rev_walk)
 
-          diff_finder.diff_with_parent(commit).each do |diff_entry|
-            if diff_entry.getNewPath != '/dev/null'
-              process_diff_entry(diff_entry, repo_config, commit) do |phrase|
-                yield phrase
+          diff_finder.diff_with_parents(commit).each_pair do |_, diff_entries|
+            diff_entries.each do |diff_entry|
+              if diff_entry.getNewPath != '/dev/null'
+                process_diff_entry(diff_entry, repo_config, commit) do |phrase|
+                  yield phrase
+                end
               end
             end
           end

--- a/lib/rosette/core/snapshots/snapshot_factory.rb
+++ b/lib/rosette/core/snapshots/snapshot_factory.rb
@@ -82,14 +82,14 @@ module Rosette
         repo = repo_config.repo
         rev_walk = RevWalk.new(repo.jgit_repo)
         rev_commit = repo.get_rev_commit(start_commit_id, rev_walk)
-        paths = make_path_set(rev_commit).to_a
+        path_set = (make_path_set(rev_commit) + paths).to_a
         num_replacements = 0
 
-        tree_filter = if paths.size > 0
-          path_filter = if repo_config && paths.empty?
+        tree_filter = if path_set.size > 0
+          path_filter = if repo_config && path_set.empty?
             RepoConfigPathFilter.create(repo_config)
           else
-            PathFilterGroup.createFromStrings(paths)
+            PathFilterGroup.createFromStrings(path_set)
           end
 
           AndTreeFilter.create(path_filter, TreeFilter::ANY_DIFF)

--- a/spec/core/git/diff_finder_spec.rb
+++ b/spec/core/git/diff_finder_spec.rb
@@ -34,28 +34,40 @@ describe DiffFinder do
 
   describe '#diff' do
     it 'returns the diff between the first two commits' do
+      commit_id = revs.first.getName
+
       diff_finder.diff(revs.first, revs.last).tap do |diff|
         expect(diff.size).to eq(1)
-        expect(diff.first.getNewPath).to eq('second_file.txt')
-        expect(diff_finder.read_new_entry(diff.first)).to eq(second_file_contents)
+        expect(diff[commit_id].first.getNewPath).to eq('second_file.txt')
+        expect(diff_finder.read_new_entry(diff[commit_id].first)).to(
+          eq(second_file_contents)
+        )
       end
     end
   end
 
   describe '#diff_with_parent' do
     it 'returns the diff between the first two commits (just as a regular diff would do)' do
-      diff_finder.diff_with_parent(revs.last).tap do |diff|
+      commit_id = revs.first.getName
+
+      diff_finder.diff_with_parents(revs.last).tap do |diff|
         expect(diff.size).to eq(1)
-        expect(diff.first.getNewPath).to eq('second_file.txt')
-        expect(diff_finder.read_new_entry(diff.first)).to eq(second_file_contents)
+        expect(diff[revs.first.getName].first.getNewPath).to eq('second_file.txt')
+        expect(diff_finder.read_new_entry(diff[revs.first.getName].first)).to(
+          eq(second_file_contents)
+        )
       end
     end
 
     it "returns the diff successfully if the rev doesn't have a parent" do
-      diff_finder.diff_with_parent(revs.first).tap do |diff|
+      commit_id = revs.first.getName
+
+      diff_finder.diff_with_parents(revs.first).tap do |diff|
         expect(diff.size).to eq(1)
-        expect(diff.first.getNewPath).to eq('first_file.txt')
-        expect(diff_finder.read_new_entry(diff.first)).to eq(first_file_contents)
+        expect(diff[commit_id].first.getNewPath).to eq('first_file.txt')
+        expect(diff_finder.read_new_entry(diff[commit_id].first)).to(
+          eq(first_file_contents)
+        )
       end
     end
   end

--- a/spec/core/git/repo_spec.rb
+++ b/spec/core/git/repo_spec.rb
@@ -60,34 +60,39 @@ describe Repo do
 
     describe '#diff' do
       it 'returns the diff when a symbolic ref is involved' do
-        repo.diff(commits.first.getName, 'HEAD').tap do |diff|
+        commit_id = commits.first.getName
+        repo.diff(commit_id, 'HEAD').tap do |diff|
           expect(diff.size).to eq(1)
-          expect(diff.first.getNewPath).to eq('second_file.txt')
+          expect(diff[commit_id].first.getNewPath).to eq('second_file.txt')
         end
       end
 
       it 'returns the diff between two shas' do
-        repo.diff(commits.first.getName, commits.last.getName).tap do |diff|
+        first_commit_id = commits.first.getName
+        second_commit_id = commits.last.getName
+        repo.diff(first_commit_id, second_commit_id).tap do |diff|
           expect(diff.size).to eq(1)
-          expect(diff.first.getNewPath).to eq('second_file.txt')
+          expect(diff[first_commit_id].first.getNewPath).to eq('second_file.txt')
         end
       end
     end
 
-    describe '#ref_diff_with_parent' do
+    describe '#ref_diff_with_parents' do
       it 'returns the correct diff' do
-        repo.ref_diff_with_parent('HEAD').tap do |diff|
+        commit_id = commits.first.getName
+        repo.ref_diff_with_parents('HEAD').tap do |diff|
           expect(diff.size).to eq(1)
-          expect(diff.first.getNewPath).to eq('second_file.txt')
+          expect(diff[commit_id].first.getNewPath).to eq('second_file.txt')
         end
       end
     end
 
-    describe '#rev_diff_with_parent' do
+    describe '#rev_diff_with_parents' do
       it 'returns the correct diff' do
-        repo.rev_diff_with_parent(repo.get_rev_commit('HEAD')).tap do |diff|
+        commit_id = commits.first.getName
+        repo.rev_diff_with_parents(repo.get_rev_commit('HEAD')).tap do |diff|
           expect(diff.size).to eq(1)
-          expect(diff.first.getNewPath).to eq('second_file.txt')
+          expect(diff[commit_id].first.getNewPath).to eq('second_file.txt')
         end
       end
     end

--- a/spec/fixtures/repos/lib/four_commits.yml
+++ b/spec/fixtures/repos/lib/four_commits.yml
@@ -1,0 +1,25 @@
+:phrases:
+  HEAD~3:
+    file1.txt:
+      - foo
+  HEAD~2:
+    file1.txt:
+      - foo
+    file2.txt:
+      - bar
+  HEAD~1:
+    file1.txt:
+      - foo
+    file2.txt:
+      - bar
+    file3.txt:
+      - baz
+  HEAD:
+    file1.txt:
+      - foo
+    file2.txt:
+      - bar
+    file3.txt:
+      - baz
+    file4.txt:
+      - goo


### PR DESCRIPTION
ShowCommand currently requires the parent commit to have been processed by Rosette. Since we’d like to eventually process commits out of order (i.e. via a queue), the parent commit may not be processed yet. This commit refactors ShowCommand to support a non-strict option, which uses the most recently processed parents instead of the commit’s true parents.

@jdoconnor @seunghyo @zvkemp 