### PR TITLE
Record the branch name when creating commit log entries

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 ruby '2.0.0', engine: 'jruby', engine_version: '1.7.15'
 
-gem 'rosette-datastore-memory', github: 'rosette-proj/rosette-datastore-memory'
+gem 'rosette-datastore-memory', github: 'rosette-proj/rosette-datastore-memory', branch: 'branch_name'
 
 group :development, :test do
   gem 'activemodel', '~> 3.2.20'

--- a/lib/rosette/core.rb
+++ b/lib/rosette/core.rb
@@ -58,6 +58,7 @@ module Rosette
 
     autoload :StringUtils,                   'rosette/core/string_utils'
 
+    autoload :Ref,                           'rosette/core/git/ref'
     autoload :Repo,                          'rosette/core/git/repo'
     autoload :DiffFinder,                    'rosette/core/git/diff_finder'
 

--- a/lib/rosette/core/extractor/commit_log.rb
+++ b/lib/rosette/core/extractor/commit_log.rb
@@ -16,13 +16,16 @@ module Rosette
     #   @return [String] the [PhraseStatus] of this commit.
     # @!attribute [rw] commit_datetime
     #   @return [DateTime] the time this commit was made.
+    # @!attribute [rw] branch_name
+    #   @return [String] the name of the branch that contains this commit.
     class CommitLog
-      def initialize(repo_name, commit_id, phrase_count = nil, status = nil, commit_datetime = nil)
+      def initialize(repo_name, commit_id, phrase_count = nil, status = nil, commit_datetime = nil, branch_name = nil)
         @repo_name = repo_name
         @commit_id = commit_id
         @phrase_count = phrase_count
         @status = status
         @commit_datetime = commit_datetime
+        @branch_name = branch_name
       end
     end
 

--- a/lib/rosette/core/git/ref.rb
+++ b/lib/rosette/core/git/ref.rb
@@ -1,0 +1,116 @@
+# encoding: UTF-8
+
+module Rosette
+  module Core
+
+    class Ref
+      DELIMITER = '/'
+
+      class << self
+        def parse(ref_name)
+          chunks = ref_name.split(DELIMITER)
+
+          if chunks.first == 'refs'
+            create_from(chunks[1..-1])
+          end
+        end
+
+        def inherited(subclass)
+          descendants << subclass
+        end
+
+        protected
+
+        def create_from(chunks)
+          descendants.each do |descendant|
+            if ref = descendant.create_from(chunks)
+              return ref
+            end
+          end
+        end
+
+        def descendants
+          @descendants ||= []
+        end
+      end
+
+      attr_reader :name
+
+      def remote?
+        type == :remote
+      end
+
+      def head?
+        type == :head
+      end
+
+      def tag?
+        type == :tag
+      end
+    end
+
+    class Remote < Ref
+      def self.create_from(chunks)
+        if chunks.first == 'remotes'
+          new(chunks[1], chunks[2..-1].join(DELIMITER))
+        end
+      end
+
+      attr_reader :remote
+
+      def initialize(remote, name)
+        @remote = remote
+        @name = name
+      end
+
+      def type
+        :remote
+      end
+
+      def to_s
+        "refs/remotes/#{remote}/#{name}"
+      end
+    end
+
+    class Head < Ref
+      def self.create_from(chunks)
+        if chunks.first == 'heads'
+          new(chunks[1..-1].join(DELIMITER))
+        end
+      end
+
+      def initialize(name)
+        @name = name
+      end
+
+      def type
+        :head
+      end
+
+      def to_s
+        "refs/heads/#{name}"
+      end
+    end
+
+    class Tag < Ref
+      def self.create_from(chunks)
+        if chunks.first == 'tags'
+          new(chunks[1..-1].join(DELIMITER))
+        end
+      end
+
+      def initialize(name)
+        @name = name
+      end
+
+      def type
+        :tag
+      end
+
+      def to_s
+        "refs/tags/#{name}"
+      end
+    end
+
+  end
+end

--- a/lib/rosette/queuing/commits/commit_job.rb
+++ b/lib/rosette/queuing/commits/commit_job.rb
@@ -94,8 +94,6 @@ module Rosette
 
           if refs.include?('refs/remotes/origin/master')
             'refs/remotes/origin/master'
-          elsif refs.include?('refs/heads/master')
-            'refs/heads/master'
           else
             filter_refs(refs).first
           end

--- a/lib/rosette/queuing/commits/stage.rb
+++ b/lib/rosette/queuing/commits/stage.rb
@@ -81,7 +81,7 @@ module Rosette
           rosette_config.datastore.add_or_update_commit_log(
             commit_log.repo_name, commit_log.commit_id,
             commit_log.commit_datetime, commit_log.status,
-            commit_log.phrase_count
+            commit_log.phrase_count, commit_log.branch_name
           )
         end
       end

--- a/spec/core/git/ref_spec.rb
+++ b/spec/core/git/ref_spec.rb
@@ -1,0 +1,118 @@
+# encoding: UTF-8
+
+require 'spec_helper'
+
+include Rosette::Core
+
+describe Ref do
+  describe '.parse' do
+    it 'parses remotes' do
+      ref = Ref.parse('refs/remotes/origin/foobar')
+      expect(ref).to be_a(Remote)
+    end
+
+    it 'parses heads' do
+      ref = Ref.parse('refs/heads/foobar')
+      expect(ref).to be_a(Head)
+    end
+
+    it 'parses tags' do
+      ref = Ref.parse('refs/tags/foobar')
+      expect(ref).to be_a(Tag)
+    end
+  end
+end
+
+describe Remote do
+  describe '.create_from' do
+    it 'creates a new remote ref' do
+      remote = Remote.create_from(%w(remotes origin foobar))
+      expect(remote.remote).to eq('origin')
+      expect(remote.name).to eq('foobar')
+    end
+  end
+
+  context 'with a remote' do
+    let(:remote) { Remote.new('origin', 'foobar') }
+
+    describe '#type' do
+      it 'returns the correct type' do
+        expect(remote.type).to eq(:remote)
+      end
+    end
+
+    describe '#to_s' do
+      it 'constructs a string representation' do
+        expect(remote.to_s).to eq('refs/remotes/origin/foobar')
+      end
+    end
+
+    it 'responds correctly to query methods' do
+      expect(remote).to be_remote
+      expect(remote).to_not be_head
+      expect(remote).to_not be_tag
+    end
+  end
+end
+
+describe Head do
+  describe '.create_from' do
+    it 'creates a new head' do
+      head = Head.create_from(%w(heads foobar))
+      expect(head.name).to eq('foobar')
+    end
+  end
+
+  context 'with a head' do
+    let(:head) { Head.new('foobar') }
+
+    describe '#type' do
+      it 'returns the correct type' do
+        expect(head.type).to eq(:head)
+      end
+    end
+
+    describe '#to_s' do
+      it 'constructs a string representation' do
+        expect(head.to_s).to eq('refs/heads/foobar')
+      end
+    end
+
+    it 'responds correctly to query methods' do
+      expect(head).to be_head
+      expect(head).to_not be_remote
+      expect(head).to_not be_tag
+    end
+  end
+end
+
+describe Tag do
+  describe '.create_from' do
+    it 'creates a new tag' do
+      tag = Tag.create_from(%w(tags foobar))
+      expect(tag.name).to eq('foobar')
+    end
+  end
+
+  context 'with a tag' do
+    let(:tag) { Tag.new('foobar') }
+
+    describe '#type' do
+      it 'returns the correct type' do
+        expect(tag.type).to eq(:tag)
+      end
+    end
+
+    describe '#to_s' do
+      it 'constructs a string representation' do
+        expect(tag.to_s).to eq('refs/tags/foobar')
+      end
+    end
+
+    it 'responds correctly to query methods' do
+      expect(tag).to be_tag
+      expect(tag).to_not be_head
+      expect(tag).to_not be_remote
+    end
+  end
+end

--- a/spec/queuing/commits/commit_conductor_spec.rb
+++ b/spec/queuing/commits/commit_conductor_spec.rb
@@ -47,7 +47,8 @@ describe CommitConductor do
         repo_name: repo_name,
         commit_id: commit_id,
         phrase_count: 0,
-        commit_datetime: nil
+        commit_datetime: nil,
+        branch_name: 'refs/heads/master'
       )
     end
 

--- a/spec/queuing/commits/commit_job_spec.rb
+++ b/spec/queuing/commits/commit_job_spec.rb
@@ -84,11 +84,20 @@ describe CommitJob do
       expect(entry.status).to eq('fake_stage_updated_me')
     end
 
-    it 'deduces the master branch when creating a new commit log from master' do
+    it 'uses the master branch if the commit exists in master' do
       InMemoryDataStore::CommitLog.entries.clear
+
+      remote_repo = TmpRepo.new
+
+      # git doesn't allow you to push to the currently checked out branch, so
+      # create a new branch to avoid an error
+      remote_repo.git('checkout -b new_branch')
+      fixture.repo.git("remote add origin #{remote_repo.working_dir}")
+      fixture.repo.git('push origin HEAD')
+
       job.work(rosette_config, logger)
       entry = InMemoryDataStore::CommitLog.entries.first
-      expect(entry.branch_name).to eq('refs/heads/master')
+      expect(entry.branch_name).to eq('refs/remotes/origin/master')
     end
 
     it 'uses the first remote ref as the branch when creating a new commit log' do

--- a/spec/queuing/commits/commit_job_spec.rb
+++ b/spec/queuing/commits/commit_job_spec.rb
@@ -9,6 +9,7 @@ include Rosette::DataStores
 describe CommitJob do
   let(:repo_name) { 'single_commit' }
   let(:commit_id) { fixture.repo.git('rev-parse HEAD').strip }
+  let(:status) { PhraseStatus::FETCHED }
 
   let(:fixture) do
     load_repo_fixture(repo_name) do |config, repo_config|
@@ -22,8 +23,13 @@ describe CommitJob do
   let(:logger) { NullLogger.new }
 
   let(:commit_log) do
-    InMemoryDataStore::CommitLog.create(
-      status: PhraseStatus::FETCHED,
+    entry = InMemoryDataStore::CommitLog.entries.find do |entry|
+      entry.commit_id == commit_id
+      entry.repo_name == repo_name
+    end
+
+    entry || InMemoryDataStore::CommitLog.create(
+      status: status,
       repo_name: repo_name,
       commit_id: commit_id,
       phrase_count: 0,
@@ -32,7 +38,7 @@ describe CommitJob do
   end
 
   let(:job) do
-    CommitJob.new(repo_name, commit_id, commit_log.status)
+    CommitJob.new(repo_name, commit_id, status)
   end
 
   before(:each) do

--- a/spec/queuing/commits/extract_stage_spec.rb
+++ b/spec/queuing/commits/extract_stage_spec.rb
@@ -25,7 +25,8 @@ describe FetchStage do
       repo_name: repo_name,
       commit_id: commit_id,
       phrase_count: 0,
-      commit_datetime: nil
+      commit_datetime: nil,
+      branch_name: 'refs/heads/master'
     )
   end
 

--- a/spec/queuing/commits/fetch_stage_spec.rb
+++ b/spec/queuing/commits/fetch_stage_spec.rb
@@ -25,7 +25,8 @@ describe FetchStage do
       repo_name: repo_name,
       commit_id: commit_id,
       phrase_count: 0,
-      commit_datetime: nil
+      commit_datetime: nil,
+      branch_name: 'refs/heads/master'
     )
   end
 

--- a/spec/queuing/commits/finalize_stage_spec.rb
+++ b/spec/queuing/commits/finalize_stage_spec.rb
@@ -28,7 +28,8 @@ describe FinalizeStage do
       repo_name: repo_name,
       commit_id: commit_id,
       phrase_count: 10,
-      commit_datetime: nil
+      commit_datetime: nil,
+      branch_name: 'refs/heads/master'
     )
   end
 

--- a/spec/queuing/commits/push_stage_spec.rb
+++ b/spec/queuing/commits/push_stage_spec.rb
@@ -26,7 +26,8 @@ describe PushStage do
       repo_name: repo_name,
       commit_id: commit_id,
       phrase_count: 0,
-      commit_datetime: nil
+      commit_datetime: nil,
+      branch_name: 'refs/heads/master'
     )
   end
 


### PR DESCRIPTION
In preparation for uploading content to Smartling by branch name instead of commit id, record the branch name in the database (i.e. tag each commit with the branch that contains it).

@jdoconnor @zvkemp @11mdlow 