### PR TITLE
Option to push new strings to TMS by branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,5 +22,5 @@ group :test do
   gem 'codeclimate-test-reporter', require: nil
   gem 'simplecov'
   gem 'rspec'
-  gem 'rosette-test-helpers', github: 'rosette-proj/rosette-test-helpers'
+  gem 'rosette-test-helpers', path: '~/workspace/rosette-test-helpers' # github: 'rosette-proj/rosette-test-helpers'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -22,5 +22,5 @@ group :test do
   gem 'codeclimate-test-reporter', require: nil
   gem 'simplecov'
   gem 'rspec'
-  gem 'rosette-test-helpers', path: '~/workspace/rosette-test-helpers' # github: 'rosette-proj/rosette-test-helpers'
+  gem 'rosette-test-helpers', github: 'rosette-proj/rosette-test-helpers', branch: 'granularity'
 end

--- a/lib/rosette/core/configurator.rb
+++ b/lib/rosette/core/configurator.rb
@@ -117,7 +117,7 @@ module Rosette
       # @param [Hash] options A hash of options passed to the queue's
       #   constructor.
       # @return [void]
-      def use_queue(queue, options = {})
+      def use_queue(queue)
         const = case queue
           when String
             if const = find_queue_const(queue)
@@ -131,7 +131,9 @@ module Rosette
             raise ArgumentError, "'#{queue}' must be a String or Class."
         end
 
-        @queue = const.new(options)
+        configurator = Rosette::Queuing::QueueConfigurator.new
+        yield configurator if block_given?
+        @queue = const.new(configurator)
         nil
       end
 

--- a/lib/rosette/queuing.rb
+++ b/lib/rosette/queuing.rb
@@ -3,11 +3,12 @@
 module Rosette
   module Queuing
 
-    autoload :Queue,   'rosette/queuing/queue'
-    autoload :Job,     'rosette/queuing/job'
-    autoload :Worker,  'rosette/queuing/worker'
+    autoload :QueueConfigurator, 'rosette/queuing/queue_configurator'
+    autoload :Job,               'rosette/queuing/job'
+    autoload :Queue,             'rosette/queuing/queue'
+    autoload :Worker,            'rosette/queuing/worker'
 
-    autoload :Commits, 'rosette/queuing/commits'
+    autoload :Commits,           'rosette/queuing/commits'
 
   end
 end

--- a/lib/rosette/queuing/commits.rb
+++ b/lib/rosette/queuing/commits.rb
@@ -4,14 +4,15 @@ module Rosette
   module Queuing
     module Commits
 
-      autoload :CommitConductor, 'rosette/queuing/commits/commit_conductor'
-      autoload :CommitJob,       'rosette/queuing/commits/commit_job'
-
-      autoload :Stage,           'rosette/queuing/commits/stage'
-      autoload :FetchStage,      'rosette/queuing/commits/fetch_stage'
-      autoload :ExtractStage,    'rosette/queuing/commits/extract_stage'
-      autoload :PushStage,       'rosette/queuing/commits/push_stage'
-      autoload :FinalizeStage,   'rosette/queuing/commits/finalize_stage'
+      autoload :CommitJob,                'rosette/queuing/commits/commit_job'
+      autoload :CommitConductor,          'rosette/queuing/commits/commit_conductor'
+      autoload :CommitsQueueConfigurator, 'rosette/queuing/commits/commits_queue_configurator'
+      autoload :ExtractStage,             'rosette/queuing/commits/extract_stage'
+      autoload :FetchStage,               'rosette/queuing/commits/fetch_stage'
+      autoload :FinalizeStage,            'rosette/queuing/commits/finalize_stage'
+      autoload :PhraseStorageGranularity, 'rosette/queuing/commits/phrase_storage_granularity'
+      autoload :PushStage,                'rosette/queuing/commits/push_stage'
+      autoload :Stage,                    'rosette/queuing/commits/stage'
 
     end
   end

--- a/lib/rosette/queuing/commits/commits_queue_configurator.rb
+++ b/lib/rosette/queuing/commits/commits_queue_configurator.rb
@@ -1,0 +1,60 @@
+# encoding: UTF-8
+
+module Rosette
+  module Queuing
+    module Commits
+
+      # Configuration specific to the "commits" queue that processes commits.
+      #
+      # @!attribute [r] name
+      #   @return [String]
+      # @!attribute [r] diff_point
+      #   @return [String] the diff point to use when computing phrase diffs.
+      #     Defaults to "master". Used only when +phrase_storage_granularity+
+      #     is set to [Rosette::Queuing::Commits::PhraseStorageGranularity::BRANCH].
+      # @!attribute [r] phrase_storage_granularity
+      #   @return [String] determines which set of phrases to push to the TMS.
+      #     Must be one of the constant values in
+      #     [Rosette::Queuing::Commits::PhraseStorageGranularity]
+      #
+      # @see Rosette::Queuing::Commits::PhraseStorageGranularity
+      class CommitsQueueConfigurator
+        DEFAULT_DIFF_POINT = 'master'
+        DEFAULT_PHRASE_GRANULARITY = PhraseStorageGranularity::COMMIT
+
+        attr_reader :name, :diff_point, :phrase_storage_granularity
+
+        # Creates a new configurator and sets up a few defaults.
+        #
+        # @param [String] name The name of the queue.
+        # @return [CommitsQueueConfigurator]
+        def initialize(name)
+          @name = name
+          @diff_point = DEFAULT_DIFF_POINT
+          @phrase_storage_granularity = DEFAULT_PHRASE_GRANULARITY
+        end
+
+        # Sets the phrase storage granularity, i.e. the method used to determine
+        # which set of phrases should get uploaded to the TMS.
+        #
+        # @param [String] granularity One of the constant values in
+        #   [Rosette::Queuing::Commits::PhraseStorageGranularity].
+        # @return [void]
+        def set_phrase_storage_granularity(granularity)
+          @phrase_storage_granularity = granularity
+        end
+
+        # Sets the diff point to use when computing phrase diffs. Note that this
+        # value is only important when +phrase_storage_granularity+ is set to
+        # [Rosette::Queuing::Commits::PhraseStorageGranularity::BRANCH].
+        #
+        # @param [String] new_diff_point The diff point to set.
+        # @return [void]
+        def set_diff_point(new_diff_point)
+          @diff_point = new_diff_point
+        end
+      end
+
+    end
+  end
+end

--- a/lib/rosette/queuing/commits/phrase_storage_granularity.rb
+++ b/lib/rosette/queuing/commits/phrase_storage_granularity.rb
@@ -1,0 +1,20 @@
+# encoding: UTF-8
+
+module Rosette
+  module Queuing
+    module Commits
+
+      # Provides a set of constants that specify how to determine the set of
+      # phrases to push to a translation management system (TMS).
+      class PhraseStorageGranularity
+        # Push only the phrases that were added or changed in single commits.
+        COMMIT = 'COMMIT'
+
+        # Push all the phrases contained by each git branch, regardless of the
+        # order of commits.
+        BRANCH = 'BRANCH'
+      end
+
+    end
+  end
+end

--- a/lib/rosette/queuing/commits/push_stage.rb
+++ b/lib/rosette/queuing/commits/push_stage.rb
@@ -27,11 +27,7 @@ module Rosette
 
           if phrases.size > 0
             commit_log.phrase_count = phrases.size
-
-            repo_config.tms.store_phrases(
-              phrases, commit_log.commit_id, granularity
-            )
-
+            repo_config.tms.store_phrases(phrases, commit_log.commit_id)
             commit_log.push
           else
             commit_log.finalize!

--- a/lib/rosette/queuing/commits/push_stage.rb
+++ b/lib/rosette/queuing/commits/push_stage.rb
@@ -5,17 +5,21 @@ module Rosette
     module Commits
 
       # Saves (or "pushes") a set of phrases from the given commit to the
-      # configured translation management system.
+      # configured translation management system (TMS).
       #
       # @see RepoConfig
       class PushStage < Stage
         accepts PhraseStatus::EXTRACTED
 
-        # Executes this stage and updates the commit log. If the given commit
-        # contains no phrases, this method doesn't push anything but will still
-        # update the commit log with a +FINALIZED+ status. If the commit no
-        # longer exists in the git repository, the commit log will be updated
-        # with a status of +MISSING+.
+        # Executes this stage and updates the commit log. If the commit queue
+        # phrase storage granularity is set to +COMMIT+, only the phrases added
+        # or modified in the given commit will get pushed to the TMS. If the
+        # granularity is instead set to +BRANCH+, the full phrase diff between
+        # the commit's branch and the configured diff point (usually master)
+        # will get pushed to the TMS. If the commit or diff contains no phrases,
+        # this method doesn't push anything but will still update the commit log
+        # with a +FINALIZED+ status. If the commit no longer exists in the git
+        # repository, the commit log will be updated with a status of +MISSING+.
         #
         # @return [void]
         def execute!
@@ -23,7 +27,11 @@ module Rosette
 
           if phrases.size > 0
             commit_log.phrase_count = phrases.size
-            repo_config.tms.store_phrases(phrases, commit_log.commit_id)
+
+            repo_config.tms.store_phrases(
+              phrases, commit_log.commit_id, granularity
+            )
+
             commit_log.push
           else
             commit_log.finalize!
@@ -38,16 +46,38 @@ module Rosette
 
         protected
 
-        def phrases
-          @phrases ||= begin
-            diff = Rosette::Core::Commands::ShowCommand.new(rosette_config)
-              .set_repo_name(repo_config.name)
-              .set_commit_id(commit_log.commit_id)
-              .set_strict(false)
-              .execute
+        def granularity
+          queue_config.phrase_storage_granularity
+        end
 
-            (diff[:added] + diff[:modified]).map(&:phrase)
+        def phrases
+          @phrases ||= case granularity
+            when PhraseStorageGranularity::COMMIT
+              phrases_from(diff_for_commit)
+            when PhraseStorageGranularity::BRANCH
+              phrases_from(diff_for_branch)
           end
+        end
+
+        def diff_for_commit
+          Rosette::Core::Commands::ShowCommand.new(rosette_config)
+            .set_repo_name(repo_config.name)
+            .set_commit_id(commit_log.commit_id)
+            .set_strict(false)
+            .execute
+        end
+
+        def diff_for_branch
+          Rosette::Core::Commands::DiffCommand.new(rosette_config)
+            .set_repo_name(repo_config.name)
+            .set_head_ref(commit_log.branch_name)
+            .set_diff_point_ref(queue_config.diff_point)
+            .set_strict(false)
+            .execute
+        end
+
+        def phrases_from(diff)
+          (diff[:added] + diff[:modified]).map(&:phrase)
         end
       end
 

--- a/lib/rosette/queuing/commits/push_stage.rb
+++ b/lib/rosette/queuing/commits/push_stage.rb
@@ -43,7 +43,16 @@ module Rosette
         protected
 
         def granularity
-          queue_config.phrase_storage_granularity
+          case queue_config.phrase_storage_granularity
+            when PhraseStorageGranularity::BRANCH
+              if commit_log.branch_name
+                PhraseStorageGranularity::BRANCH
+              else
+                PhraseStorageGranularity::COMMIT
+              end
+            else
+              queue_config.phrase_storage_granularity
+          end
         end
 
         def phrases

--- a/lib/rosette/queuing/commits/stage.rb
+++ b/lib/rosette/queuing/commits/stage.rb
@@ -84,6 +84,11 @@ module Rosette
             commit_log.phrase_count, commit_log.branch_name
           )
         end
+
+        def queue_config
+          @queue_config ||=
+            rosette_config.queue.configurator.get_queue_config('commits')
+        end
       end
 
     end

--- a/lib/rosette/queuing/queue_configurator.rb
+++ b/lib/rosette/queuing/queue_configurator.rb
@@ -1,0 +1,75 @@
+# encoding: UTF-8
+
+module Rosette
+  module Queuing
+
+    # Configuration used to initialize a queue implementation.
+    #
+    # @!attribute [r] queue_options
+    #   @return [Hash] a hash of options to be used by the queue implementation.
+    # @!attribute [r] queue_configs
+    #   @return [Array] an array of queue config objects. These classes are
+    #     provided by each type of queue. For example, the queue that processes
+    #     commits (see [Rosette::Queuing::Commits]) defines its own configurator
+    #     that gets instantiated and added to this array.
+    class QueueConfigurator
+      attr_reader :queue_options, :queue_configs
+
+      # Creates a new +QueueConfigurator+ instance.
+      #
+      # @return [QueueConfigurator]
+      def initialize
+        @queue_configs = []
+      end
+
+      # Sets an options hash that will be used to initialize the underlying
+      # queue implementation (eg. resque, sidekiq, etc).
+      #
+      # @param [Hash] options The options hash to use to initialize the
+      #   underlying queue implementation (eg. resque, sidekiq, etc).
+      # @return [void]
+      def set_queue_options(options = {})
+        @queue_options = options
+      end
+
+      # Configures and adds a queue to process jobs from. Note that the term
+      # "queue" here refers to a sequence of jobs, not a queue implementation.
+      #
+      # @param [String] queue_name The name of the queue to configure.
+      # @return [void]
+      def enable_queue(queue_name)
+        if const = find_queue_configurator_const(queue_name)
+          config = const.new(queue_name)
+          yield config if block_given?
+          queue_configs << config
+        else
+          raise ArgumentError, "'#{queue_name}' couldn't be found."
+        end
+      end
+
+      # Looks up a queue configuration object by name.
+      #
+      # @param [String] queue_name The name of the queue to look up.
+      # @return [Object, nil] The queue config object, or +nil+ if none could
+      #   be found.
+      def get_queue_config(queue_name)
+        queue_configs.find { |q| q.name == queue_name }
+      end
+
+      protected
+
+      def find_queue_configurator_const(name)
+        const_str = Rosette::Core::StringUtils.camelize(name)
+
+        if Rosette::Queuing.const_defined?(const_str)
+          mod = Rosette::Queuing.const_get(const_str)
+
+          if mod.const_defined?(:"#{const_str}QueueConfigurator")
+            mod.const_get(:"#{const_str}QueueConfigurator")
+          end
+        end
+      end
+    end
+
+  end
+end

--- a/lib/rosette/queuing/queue_configurator.rb
+++ b/lib/rosette/queuing/queue_configurator.rb
@@ -19,6 +19,7 @@ module Rosette
       #
       # @return [QueueConfigurator]
       def initialize
+        @queue_options = {}
         @queue_configs = []
       end
 

--- a/lib/rosette/tms/repository.rb
+++ b/lib/rosette/tms/repository.rb
@@ -3,8 +3,6 @@
 module Rosette
   module Tms
     class Repository
-      PhraseStorageGranularity = Rosette::Queuing::Commits::PhraseStorageGranularity
-
       # Creates a new instance of this repository.
       #
       # @param [Object] configurator The implementation-specific configuration
@@ -43,7 +41,7 @@ module Rosette
       # @param [Array<Phrase>] phrases The list of phrases to store.
       # @param [String] commit_id The commit id to associate the phrases with.
       # @return [void]
-      def store_phrases(phrases, commit_id, granularity = PhraseStorageGranularity::COMMIT)
+      def store_phrases(phrases, commit_id)
         raise NotImplementedError,
           'expected to be implemented in derived classes'
       end
@@ -54,7 +52,7 @@ module Rosette
       # @param [Phrase] phrase The phrase to store.
       # @param [String] commit_id The commit id to associate the phrase with.
       # @return [void]
-      def store_phrase(phrase, commit_id, granularity = PhraseStorageGranularity::COMMIT)
+      def store_phrase(phrase, commit_id)
         raise NotImplementedError,
           'expected to be implemented in derived classes'
       end

--- a/lib/rosette/tms/repository.rb
+++ b/lib/rosette/tms/repository.rb
@@ -3,6 +3,7 @@
 module Rosette
   module Tms
     class Repository
+      PhraseStorageGranularity = Rosette::Queuing::Commits::PhraseStorageGranularity
 
       # Creates a new instance of this repository.
       #
@@ -42,7 +43,7 @@ module Rosette
       # @param [Array<Phrase>] phrases The list of phrases to store.
       # @param [String] commit_id The commit id to associate the phrases with.
       # @return [void]
-      def store_phrases(phrases, commit_id)
+      def store_phrases(phrases, commit_id, granularity = PhraseStorageGranularity::COMMIT)
         raise NotImplementedError,
           'expected to be implemented in derived classes'
       end
@@ -53,7 +54,7 @@ module Rosette
       # @param [Phrase] phrase The phrase to store.
       # @param [String] commit_id The commit id to associate the phrase with.
       # @return [void]
-      def store_phrase(phrase, commit_id)
+      def store_phrase(phrase, commit_id, granularity = PhraseStorageGranularity::COMMIT)
         raise NotImplementedError,
           'expected to be implemented in derived classes'
       end

--- a/spec/queuing/commits/push_stage_spec.rb
+++ b/spec/queuing/commits/push_stage_spec.rb
@@ -7,12 +7,14 @@ include Rosette::DataStores
 
 describe PushStage do
   let(:repo_name) { 'single_commit' }
-  let(:commit_id) { fixture.repo.git('rev-parse HEAD').strip }
 
   let(:fixture) do
     load_repo_fixture(repo_name) do |config, repo_config|
-      config.use_datastore('in-memory')
       repo_config.use_tms('test')
+      config.use_datastore('in-memory')
+      config.use_queue('test') do |queue_config|
+        queue_config.enable_queue('commits')
+      end
     end
   end
 
@@ -20,61 +22,116 @@ describe PushStage do
   let(:repo_config) { rosette_config.get_repo(repo_name) }
   let(:logger) { NullLogger.new }
 
-  let(:commit_log) do
-    InMemoryDataStore::CommitLog.create(
-      status: PhraseStatus::FETCHED,
-      repo_name: repo_name,
-      commit_id: commit_id,
-      phrase_count: 0,
-      commit_datetime: nil,
-      branch_name: 'refs/heads/master'
-    )
-  end
-
-  let(:stage) do
-    PushStage.new(rosette_config, repo_config, logger, commit_log)
-  end
-
   describe '#execute!' do
+    context 'with a single commit' do
+      let(:commit_log) do
+        InMemoryDataStore::CommitLog.create(
+          status: PhraseStatus::FETCHED,
+          repo_name: repo_name,
+          commit_id: commit_id,
+          phrase_count: 0,
+          commit_datetime: nil,
+          branch_name: 'refs/heads/master'
+        )
+      end
+
+      let(:stage) do
+        PushStage.new(rosette_config, repo_config, logger, commit_log)
+      end
+
+      let(:commit_id) { fixture.repo.git('rev-parse HEAD').strip }
+
+      before(:each) do
+        args = [rosette_config, repo_config, logger, commit_log]
+        ExtractStage.new(*args).execute!
+      end
+
+      it 'updates the status to FINALIZED when no phrases are found' do
+        expect(stage).to receive(:phrases).and_return([])
+        stage.execute!
+        expect(commit_log.status).to eq(PhraseStatus::FINALIZED)
+      end
+
+      it 'stores the phrases in the repository' do
+        stage.execute!
+        phrases = repo_config.tms.stored_phrases[commit_id].map(&:key)
+        expect(phrases).to include('The green albatross flitters in the moonlight')
+        expect(phrases).to include('Chatanooga Choo Choo')
+        expect(phrases).to include(' test string 1')
+      end
+
+      it 'updates the commit log status' do
+        stage.execute!
+        expect(commit_log.status).to eq(PhraseStatus::PUSHED)
+      end
+
+      it "updates the status to MISSING if one of the objects doesn't exist" do
+        fixture.repo.git('reset --hard HEAD')
+        fixture.repo.create_file('testfile.txt') { |f| f.write('foo') }
+        fixture.repo.add_all
+        fixture.repo.commit('Test commit')
+
+        commit_log.commit_id = fixture.repo.git('rev-parse HEAD').strip
+
+        fixture.repo.git('reset --hard HEAD~1')
+        fixture.repo.git('reflog expire --expire=now --all')
+        fixture.repo.git('fsck --unreachable')
+        fixture.repo.git('prune -v')
+
+        stage.execute!
+        expect(commit_log.status).to eq(PhraseStatus::MISSING)
+      end
+    end
+  end
+
+  context 'with a git branch' do
     before(:each) do
-      args = [rosette_config, repo_config, logger, commit_log]
-      ExtractStage.new(*args).execute!
-    end
+      fixture.repo.create_branch('my_branch')
 
-    it 'updates the status to FINALIZED when no phrases are found' do
-      expect(stage).to receive(:phrases).and_return([])
-      stage.execute!
-      expect(commit_log.status).to eq(PhraseStatus::FINALIZED)
-    end
-
-    it 'stores the phrases in the repository' do
-      stage.execute!
-      phrases = repo_config.tms.stored_phrases[commit_id].map(&:key)
-      expect(phrases).to include('The green albatross flitters in the moonlight')
-      expect(phrases).to include('Chatanooga Choo Choo')
-      expect(phrases).to include(' test string 1')
-    end
-
-    it 'updates the commit log status' do
-      stage.execute!
-      expect(commit_log.status).to eq(PhraseStatus::PUSHED)
-    end
-
-    it "updates the status to MISSING if one of the objects doesn't exist" do
-      fixture.repo.git('reset --hard HEAD')
-      fixture.repo.create_file('testfile.txt') { |f| f.write('foo') }
+      fixture.repo.create_file('testfile.txt') { |f| f.write('first') }
       fixture.repo.add_all
       fixture.repo.commit('Test commit')
 
-      commit_log.commit_id = fixture.repo.git('rev-parse HEAD').strip
+      fixture.repo.create_file('anothertestfile.txt') { |f| f.write('second') }
+      fixture.repo.add_all
+      fixture.repo.commit('Another test commit')
 
-      fixture.repo.git('reset --hard HEAD~1')
-      fixture.repo.git('reflog expire --expire=now --all')
-      fixture.repo.git('fsck --unreachable')
-      fixture.repo.git('prune -v')
+      fixture.repo.each_commit_id do |commit_id|
+        commit_log = InMemoryDataStore::CommitLog.create(
+          status: PhraseStatus::FETCHED,
+          repo_name: repo_name,
+          commit_id: commit_id,
+          phrase_count: 0,
+          commit_datetime: nil,
+          branch_name: 'refs/heads/my_branch'
+        )
 
-      stage.execute!
-      expect(commit_log.status).to eq(PhraseStatus::MISSING)
+        args = [rosette_config, repo_config, logger, commit_log]
+        ExtractStage.new(*args).execute!
+      end
+    end
+
+    context 'with phrase storage granularity set to BRANCH' do
+      before(:each) do
+        queue = rosette_config.queue.configurator.get_queue_config('commits')
+        queue.set_phrase_storage_granularity(PhraseStorageGranularity::BRANCH)
+      end
+
+      let(:commit_log) do
+        InMemoryDataStore::CommitLog.entries.last
+      end
+
+      let(:stage) do
+        PushStage.new(rosette_config, repo_config, logger, commit_log)
+      end
+
+      describe '#execute' do
+        it 'pushes all the phrases in the branch' do
+          stage.execute!
+          phrases = repo_config.tms.stored_phrases[commit_log.commit_id]
+          expect(phrases.map(&:key)).to eq(%w(second first))
+        end
+      end
     end
   end
 end

--- a/spec/queuing/commits/push_stage_spec.rb
+++ b/spec/queuing/commits/push_stage_spec.rb
@@ -118,7 +118,7 @@ describe PushStage do
       end
 
       let(:commit_log) do
-        InMemoryDataStore::CommitLog.entries.last
+        InMemoryDataStore::CommitLog.entries.first
       end
 
       let(:stage) do
@@ -129,7 +129,15 @@ describe PushStage do
         it 'pushes all the phrases in the branch' do
           stage.execute!
           phrases = repo_config.tms.stored_phrases[commit_log.commit_id]
-          expect(phrases.map(&:key)).to eq(%w(second first))
+          keys = phrases.map(&:key)
+          expect(keys).to eq(%w(second first))
+        end
+
+        it 'pushes by commit if the branch name is null' do
+          commit_log.branch_name = nil
+          stage.execute!
+          phrases = repo_config.tms.stored_phrases[commit_log.commit_id]
+          expect(phrases.map(&:key)).to eq(%w(second))
         end
       end
     end

--- a/spec/queuing/queue_configurator_spec.rb
+++ b/spec/queuing/queue_configurator_spec.rb
@@ -1,0 +1,44 @@
+# encoding: UTF-8
+
+require 'spec_helper'
+
+include Rosette::Queuing
+
+describe QueueConfigurator do
+  let(:configurator) { QueueConfigurator.new }
+
+  describe '#enable_queue' do
+    it "raises an error if the queue can't be determined" do
+      expect { configurator.enable_queue('foo') }.to raise_error
+    end
+
+    it 'adds the queue config to the list of configured queues' do
+      expect { configurator.enable_queue('commits') }.to(
+        change { configurator.queue_configs.size }.from(0).to(1)
+      )
+
+      expect(configurator.queue_configs.first).to(
+        be_a(Commits::CommitsQueueConfigurator)
+      )
+    end
+  end
+
+  context 'with a queue configured' do
+    let(:queue_name) { 'commits' }
+
+    before(:each) do
+      configurator.enable_queue(queue_name)
+    end
+
+    describe '#get_queue_config' do
+      it 'gets the queue by name' do
+        queue_config = configurator.get_queue_config(queue_name)
+        expect(queue_config).to be_a(Commits::CommitsQueueConfigurator)
+      end
+
+      it 'returns nil if no config could be found' do
+        expect(configurator.get_queue_config('foo')).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
In this PR:

1. Introduces per-queue configuration, i.e. configuration specifically for the "commits" queue.
2. Introduces the concept of phrase storage granularity (see the `PhraseStorageGranularity` class), which offers phrase storage by branch or by commit (the default).

@jdoconnor @11mdlow @zvkemp @seunghyo 