### PR TITLE
Adding UntranslatedPhrasesCommand

### DIFF
--- a/lib/rosette/core/commands.rb
+++ b/lib/rosette/core/commands.rb
@@ -8,29 +8,30 @@ module Rosette
     # Namespace for all Rosette commands.
     module Commands
 
-      autoload :Errors,                   'rosette/core/commands/errors'
+      autoload :Errors,                     'rosette/core/commands/errors'
 
-      autoload :CommitCommand,            'rosette/core/commands/git/commit_command'
-      autoload :DiffBaseCommand,          'rosette/core/commands/git/diff_base_command'
-      autoload :DiffCommand,              'rosette/core/commands/git/diff_command'
-      autoload :ShowCommand,              'rosette/core/commands/git/show_command'
-      autoload :StatusCommand,            'rosette/core/commands/git/status_command'
-      autoload :FetchCommand,             'rosette/core/commands/git/fetch_command'
-      autoload :SnapshotCommand,          'rosette/core/commands/git/snapshot_command'
-      autoload :RepoSnapshotCommand,      'rosette/core/commands/git/repo_snapshot_command'
-      autoload :WithRepoName,             'rosette/core/commands/git/with_repo_name'
-      autoload :WithRef,                  'rosette/core/commands/git/with_ref'
-      autoload :WithRefs,                 'rosette/core/commands/git/with_refs'
-      autoload :WithNonMergeRef,          'rosette/core/commands/git/with_non_merge_ref'
-      autoload :WithSnapshots,            'rosette/core/commands/git/with_snapshots'
-      autoload :DiffEntry,                'rosette/core/commands/git/diff_entry'
+      autoload :CommitCommand,              'rosette/core/commands/git/commit_command'
+      autoload :DiffBaseCommand,            'rosette/core/commands/git/diff_base_command'
+      autoload :DiffCommand,                'rosette/core/commands/git/diff_command'
+      autoload :ShowCommand,                'rosette/core/commands/git/show_command'
+      autoload :StatusCommand,              'rosette/core/commands/git/status_command'
+      autoload :FetchCommand,               'rosette/core/commands/git/fetch_command'
+      autoload :SnapshotCommand,            'rosette/core/commands/git/snapshot_command'
+      autoload :RepoSnapshotCommand,        'rosette/core/commands/git/repo_snapshot_command'
+      autoload :WithRepoName,               'rosette/core/commands/git/with_repo_name'
+      autoload :WithRef,                    'rosette/core/commands/git/with_ref'
+      autoload :WithRefs,                   'rosette/core/commands/git/with_refs'
+      autoload :WithNonMergeRef,            'rosette/core/commands/git/with_non_merge_ref'
+      autoload :WithSnapshots,              'rosette/core/commands/git/with_snapshots'
+      autoload :DiffEntry,                  'rosette/core/commands/git/diff_entry'
 
-      autoload :WithLocale,               'rosette/core/commands/translations/with_locale'
-      autoload :ExportCommand,            'rosette/core/commands/translations/export_command'
-      autoload :TranslationLookupCommand, 'rosette/core/commands/translations/translation_lookup_command'
+      autoload :WithLocale,                 'rosette/core/commands/translations/with_locale'
+      autoload :ExportCommand,              'rosette/core/commands/translations/export_command'
+      autoload :TranslationLookupCommand,   'rosette/core/commands/translations/translation_lookup_command'
+      autoload :UntranslatedPhrasesCommand, 'rosette/core/commands/translations/untranslated_phrases_command'
 
-      autoload :EnqueueCommitCommand,     'rosette/core/commands/queuing/enqueue_commit_command'
-      autoload :RequeueCommitCommand,     'rosette/core/commands/queuing/requeue_commit_command'
+      autoload :EnqueueCommitCommand,       'rosette/core/commands/queuing/enqueue_commit_command'
+      autoload :RequeueCommitCommand,       'rosette/core/commands/queuing/requeue_commit_command'
 
       # Base class for all Rosette commands.
       #

--- a/lib/rosette/core/commands/translations/translation_lookup_command.rb
+++ b/lib/rosette/core/commands/translations/translation_lookup_command.rb
@@ -6,9 +6,6 @@ module Rosette
 
       # Returns the translation for the given phrase and locale combination.
       #
-      # @!attribute [r] locale
-      #   @return [String] the locale to export translations for.
-      #
       # @example
       #   cmd = TranslationLookupCommand.new(configuration)
       #     .set_repo_name('my_repo')

--- a/lib/rosette/core/commands/translations/untranslated_phrases_command.rb
+++ b/lib/rosette/core/commands/translations/untranslated_phrases_command.rb
@@ -1,0 +1,46 @@
+# encoding: UTF-8
+
+module Rosette
+  module Core
+    module Commands
+
+      # Returns the list of phrases per locale that have not yet been translated
+      # for the given repo and commit.
+      #
+      # @example
+      #   cmd = UntranslatedPhrasesCommand.new(configuration)
+      #     .set_repo_name('my_repo')
+      #     .set_ref('master')
+      #
+      #   cmd.execute
+      #   # => {
+      #       "fr-FR" => [
+      #         <Phrase>, <Phrase>, ...
+      #       ]
+      #   # }
+      class UntranslatedPhrasesCommand < GitCommand
+        include WithRepoName
+        include WithRef
+
+        def execute
+          phrases = datastore.phrases_by_commit(repo_name, commit_id)
+          result = Hash.new { |h, k| h[k] = [] }
+
+          repo_config.locales.each_with_object(result) do |locale, ret|
+            phrases.each do |phrase|
+              trans = repo_config.tms.lookup_translation(locale, phrase)
+              result[locale.code] << phrase
+            end
+          end
+        end
+
+        protected
+
+        def repo_config
+          get_repo(repo_name)
+        end
+      end
+
+    end
+  end
+end

--- a/lib/rosette/core/commands/translations/untranslated_phrases_command.rb
+++ b/lib/rosette/core/commands/translations/untranslated_phrases_command.rb
@@ -29,7 +29,7 @@ module Rosette
           repo_config.locales.each_with_object(result) do |locale, ret|
             phrases.each do |phrase|
               trans = repo_config.tms.lookup_translation(locale, phrase)
-              result[locale.code] << phrase
+              result[locale.code] << phrase unless trans
             end
           end
         end

--- a/spec/core/commands/translations/export_command_spec.rb
+++ b/spec/core/commands/translations/export_command_spec.rb
@@ -54,6 +54,13 @@ describe ExportCommand do
     end
   end
 
+  it 'falls back to source if no translation is found' do
+    phrase = phrase_model.entries.first
+    repo_config.tms.translations.delete(phrase.index_value)
+    result = command.execute
+    expect(result[:payload]).to include("#{phrase.key} = #{phrase.key}")
+  end
+
   it 'includes basic information about the payload' do
     result = command.execute
     expect(result[:encoding]).to eq('UTF-8')

--- a/spec/core/commands/translations/untranslated_phrases_command_spec.rb
+++ b/spec/core/commands/translations/untranslated_phrases_command_spec.rb
@@ -1,0 +1,55 @@
+# encoding: UTF-8
+
+require 'spec_helper'
+
+include Rosette::Core::Commands
+include Rosette::DataStores
+# include Rosette::Core
+
+describe UntranslatedPhrasesCommand do
+  let(:repo_name) { 'single_commit' }
+  let(:locale) { repo_config.locales.first }
+  let(:rosette_config) { fixture.config }
+  let(:repo_config) { rosette_config.get_repo(repo_name) }
+  let(:commit_id) { fixture.repo.git('rev-parse HEAD').strip }
+
+  let(:fixture) do
+    load_repo_fixture(repo_name) do |config, repo_config|
+      config.use_datastore('in-memory')
+      repo_config.use_tms('test')
+      repo_config.add_locale('de-DE')
+    end
+  end
+
+  let(:command) do
+    UntranslatedPhrasesCommand.new(rosette_config)
+      .set_repo_name(repo_name)
+      .set_commit_id(commit_id)
+  end
+
+  describe '#execute' do
+    before(:each) do
+      fixture.repo.each_commit_id do |commit_id|
+        CommitCommand.new(rosette_config)
+          .set_repo_name(repo_name)
+          .set_commit_id(commit_id)
+          .execute
+      end
+    end
+
+    it 'identifies the missing translation' do
+      InMemoryDataStore::Phrase.entries.each_with_index do |phrase, idx|
+        next if idx == 0  # skip one translation
+        repo_config.tms.auto_translate(locale, phrase)
+      end
+
+      untrans = InMemoryDataStore::Phrase.entries.first
+
+      result = command.execute
+      expect(result).to include('de-DE')
+      expect(result['de-DE'].size).to eq(1)
+      expect(result['de-DE'].first.key).to eq(untrans.key)
+      expect(result['de-DE'].first.meta_key).to eq(untrans.meta_key)
+    end
+  end
+end

--- a/spec/queuing/queue_configurator_spec.rb
+++ b/spec/queuing/queue_configurator_spec.rb
@@ -9,7 +9,7 @@ describe QueueConfigurator do
 
   describe '#enable_queue' do
     it "raises an error if the queue can't be determined" do
-      expect { configurator.enable_queue('foo') }.to raise_error
+      expect { configurator.enable_queue('foo') }.to raise_error(ArgumentError)
     end
 
     it 'adds the queue config to the list of configured queues' do


### PR DESCRIPTION
Brian asked me yesterday if there was a way of seeing which strings are untranslated for a given commit or ref, and I said no. After thinking a bit more about it though, I came up with this solution. It asks the TMS for translations and reports the phrases for which it returns `nil`.

@jdoconnor @11mdlow @zvkemp @seunghyo 