### PR TITLE
Distribute consecutive finalize jobs

### DIFF
--- a/lib/rosette/queuing/commits/finalize_stage.rb
+++ b/lib/rosette/queuing/commits/finalize_stage.rb
@@ -14,7 +14,8 @@ module Rosette
         # The number of seconds to wait in between consecutive pulls. This value
         # will be passed to the queue implementation, as delay is handled at the
         # queue layer.
-        CONSECUTIVE_FINALIZE_DELAY = 10 * 60  # 10 minutes
+        CONSECUTIVE_FINALIZE_DELAY_MIN = 10 * 60  # 10 minutes
+        CONSECUTIVE_FINALIZE_DELAY_MAX = 45 * 60  # 45 minutes
 
         # Executes this stage and updates the commit log. If the commit has been
         # fully translated, the commit log will be updated with a +FINALIZED+
@@ -58,9 +59,15 @@ module Rosette
         def to_job
           super.tap do |job|
             if commit_log.status == PhraseStatus::PUSHED
-              job.set_delay(CONSECUTIVE_FINALIZE_DELAY)
+              job.set_delay(random_delay)
             end
           end
+        end
+
+        protected
+
+        def random_delay
+          rand(CONSECUTIVE_FINALIZE_DELAY_MIN..CONSECUTIVE_FINALIZE_DELAY_MAX)
         end
       end
 

--- a/spec/queuing/commits/finalize_stage_spec.rb
+++ b/spec/queuing/commits/finalize_stage_spec.rb
@@ -72,4 +72,17 @@ describe FinalizeStage do
       end
     end
   end
+
+  describe '#to_job' do
+    it 'adds a delay to the job if the status is still PUSHED' do
+      job = stage.to_job
+      expect(job.delay).to be > 0
+    end
+
+    it 'does not add a delay if the job is FINALIZED' do
+      stage.commit_log.status = PhraseStatus::FINALIZED
+      job = stage.to_job
+      expect(job.delay).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
Consecutive finalize jobs now get delayed between 10 and 45 minutes in an effort to distribute the number of jobs scheduled for any given minute over a wider range.

We've been seeing quite a queue backup with the new push-by-branch feature because consecutive finalize jobs (i.e. translations aren't done, so wait a bit and try again) are always delayed by exactly 10 minutes. Jobs that get delayed back-to-back are re-enqueued at almost the same time, causing a large number of jobs to be enqueued at once.

By choosing a random amount of time to delay (within a min and max), jobs should be more evenly distributed and not pile up.

@jdoconnor @11mdlow @zvkemp @seunghyo 