### PR TITLE
customizable config times for the finalize stage delay

### DIFF
--- a/lib/rosette/queuing/commits/finalize_stage.rb
+++ b/lib/rosette/queuing/commits/finalize_stage.rb
@@ -14,8 +14,8 @@ module Rosette
         # The number of seconds to wait in between consecutive pulls. This value
         # will be passed to the queue implementation, as delay is handled at the
         # queue layer.
-        CONSECUTIVE_FINALIZE_DELAY_MIN = 10 * 60  # 10 minutes
-        CONSECUTIVE_FINALIZE_DELAY_MAX = 45 * 60  # 45 minutes
+        CONSECUTIVE_FINALIZE_DELAY_MIN = ENV.fetch('CONSECUTIVE_FINALIZE_DELAY_MIN', 10 * 60) # 10 minutes
+        CONSECUTIVE_FINALIZE_DELAY_MAX = ENV.fetch('CONSECUTIVE_FINALIZE_DELAY_MAX', 45 * 60) # 45 minutes
 
         # Executes this stage and updates the commit log. If the commit has been
         # fully translated, the commit log will be updated with a +FINALIZED+


### PR DESCRIPTION
@camertron 

I want to see this customizable. In some cases, the queue is just churning through jobs and doing nothing, but blocking other jobs. Another way to go about this is to prioritize the queue. I've seen situations (like today) where there are more than 1400 commits not yet finalized.

Good problems to have, I guess :)
