### PR TITLE
break the finalize stage into a different queue

### DIFF
--- a/lib/rosette/queuing/commits/commit_job.rb
+++ b/lib/rosette/queuing/commits/commit_job.rb
@@ -16,7 +16,7 @@ module Rosette
       class CommitJob < Job
         attr_reader :repo_name, :commit_id, :status
 
-        set_queue_name 'commits'
+        set_queue 'commits'
 
         # Creates a new [CommitJob] object from a [Stage].
         #

--- a/lib/rosette/queuing/commits/finalize_stage.rb
+++ b/lib/rosette/queuing/commits/finalize_stage.rb
@@ -60,6 +60,7 @@ module Rosette
           super.tap do |job|
             if commit_log.status == PhraseStatus::PUSHED
               job.set_delay(random_delay)
+              job.set_queue('finalize')
             end
           end
         end

--- a/lib/rosette/queuing/job.rb
+++ b/lib/rosette/queuing/job.rb
@@ -17,18 +17,18 @@ module Rosette
         # ignored.
         #
         # @return [String] The name of the queue.
-        def queue_name
-          @queue_name || DEFAULT_QUEUE_NAME
+        def queue
+          @queue || DEFAULT_QUEUE_NAME
         end
 
         # Sets the name of the queue this job will be run in. Implementations
         # that don't offer named queues shouldn't need to call this method,
         # although nothing bad will happen if they do.
         #
-        # @param [String] queue_name The name of the queue to run the job in.
+        # @param [String] queue The name of the queue to run the job in.
         # @return [void]
-        def set_queue_name(queue_name)
-          @queue_name = queue_name
+        def set_queue(queue)
+          @queue = queue
         end
       end
 
@@ -67,6 +67,14 @@ module Rosette
       # @return [void]
       def set_delay(delay)
         @delay = delay
+      end
+
+      # Sets the queue for this specific job instance
+      #
+      # @param [String] queue The name of the queue
+      # @return [String] The name of the queue
+      def set_queue(queue)
+        @queue = queue
       end
     end
 

--- a/spec/queuing/job_spec.rb
+++ b/spec/queuing/job_spec.rb
@@ -7,14 +7,14 @@ include Rosette::Queuing
 describe Job do
   let(:job_class) { Class.new(Job) }
 
-  describe '.queue_name' do
+  describe '.queue' do
     it 'returns the default queue name' do
-      expect(job_class.queue_name).to eq('default')
+      expect(job_class.queue).to eq('default')
     end
 
     it 'returns a custom queue name' do
-      job_class.set_queue_name('foobar')
-      expect(job_class.queue_name).to eq('foobar')
+      job_class.set_queue('foobar')
+      expect(job_class.queue).to eq('foobar')
     end
   end
 


### PR DESCRIPTION
@camertron @11mdlow 

Based on the resque implementation, the queue instance variable takes precedence over the queue class variable. Therefore, we can set the queue when we make the job.
https://github.com/resque/resque/blob/cb337e134c21a8c87db2a9d6bf090e083af6a950/lib/resque.rb#L397-L398

This will enable "higher priority" stages to be prioritized by the resque workers