### PR TITLE
Update commit_job.rb

### DIFF
--- a/lib/rosette/queuing/commits/commit_job.rb
+++ b/lib/rosette/queuing/commits/commit_job.rb
@@ -14,7 +14,7 @@ module Rosette
       #   @return [String] the current status of the commit (mostly for display
       #     and tracking purposes).
       class CommitJob < Job
-        attr_reader :repo_name, :commit_id, :status
+        attr_reader :repo_name, :commit_id, :status, :queue
 
         set_queue 'commits'
 


### PR DESCRIPTION
@camertron 
There are a lot of layers of abstraction over the queue. This is a place where we read from in the queue worker

This finally works (although, it is confusing because scheduled jobs don't appear immediately in resqueweb, but there's a fix for that)
